### PR TITLE
Updated mqtt to version 1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "noflo": "0.5.14",
-    "mqtt": "0.3.13"
+    "mqtt": "1.4.2"
   },
   "devDependencies": {
     "grunt": "0.4.5",


### PR DESCRIPTION
:rocket:

mqtt just published version 1.4.2, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

[GitHub Release](https://github.com/mqttjs/MQTT.js/releases/tag/v1.4.2)
- Added key, cert, ca options to the CLI #327 by @janjongboom

---

The new version differs by 223 commits (ahead by 223, behind by 0).
- [6f0d515](https://github.com/mqttjs/MQTT.js/commit/6f0d5154622a92264400c7d4a1e8ac9399b782fb): Bumped v1.4.2.
- [dc41bc9](https://github.com/mqttjs/MQTT.js/commit/dc41bc9d555dd9a57abd3831768204c0fe427140): Merge pull request #327 from janjongboom/cli_key_cert
- [335190d](https://github.com/mqttjs/MQTT.js/commit/335190d17837b361be95ced1be75bcf5a322395d): Allow key, cert, ca to be passed into cli. Don't break if no message is specified during pub.
- [d420f1e](https://github.com/mqttjs/MQTT.js/commit/d420f1e417a2c96a510b8cd604d553c360074359): Updated travis to node 4.
- [45f2b4a](https://github.com/mqttjs/MQTT.js/commit/45f2b4aef208e58802092bcbdce7ce22a7fbf458): Corrected linting.
- [8bbbfcc](https://github.com/mqttjs/MQTT.js/commit/8bbbfcc7513422e73962228ef3a4fe24402e5b59): Merge pull request #326 from eiriksm/patch-1
- [0e48dab](https://github.com/mqttjs/MQTT.js/commit/0e48dabeb79fe7a883e505718b43acdba2206c5f): Use svg version of travis badge
- [f157ed2](https://github.com/mqttjs/MQTT.js/commit/f157ed2497e93dbc7f860a19bb3121448d67c291): 1.4.1
- [193bba9](https://github.com/mqttjs/MQTT.js/commit/193bba91a9b7d39f85962ae1fbc50fb5431c66b5): Accept the -l option in the publish command
- [44c6158](https://github.com/mqttjs/MQTT.js/commit/44c615834bc8e4d00089016b62b84cf2f4d6fc65): Merge pull request #319 from imZack/master
- [9eeff5e](https://github.com/mqttjs/MQTT.js/commit/9eeff5e099e583eb79f6b83c2f245146c4a68d61): Update README.md
- [7632388](https://github.com/mqttjs/MQTT.js/commit/7632388ac5c9470e430dc9aa6dea8f8b58367014): Add Webpack support without errors.
- [69350c0](https://github.com/mqttjs/MQTT.js/commit/69350c03e88bd9af9c16b4b01848bc3c893a775c): Bumped 1.4.0.
- [fe7196b](https://github.com/mqttjs/MQTT.js/commit/fe7196b23388fd71c90f67764e150b2470be6da8): Merge pull request #315 from mqttjs/bumped-depdencies
- [4c6ba65](https://github.com/mqttjs/MQTT.js/commit/4c6ba65a3370d834bfd0e9030df47bc3b51b4d08): removed unnecesary comments and corrected styling for new eslint

There are 223 commits in total. See the [full diff](https://github.com/mqttjs/MQTT.js/compare/388a084d7803934b18b43c1146c817deaa1396b1...6f0d5154622a92264400c7d4a1e8ac9399b782fb).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
